### PR TITLE
Remove log.debug() in buildData()

### DIFF
--- a/hubigraph_range_bar.groovy
+++ b/hubigraph_range_bar.groovy
@@ -355,7 +355,7 @@ def buildData() {
     def now = new Date();
     def then = new Date();
     
-    log.debug(graph_timespan);
+    //log.debug(graph_timespan);
     switch (graph_timespan){
         case "0": //"Live":
         break;


### PR DESCRIPTION
I'm constantly getting a debug "2" in the log from this app. It's coming from log.debug(graph_timespan); on line 358, so I've commented that line. I don't think it's needed.