### PR TITLE
Add onTileLoad and onTileUnload hooks to run commands of the sensor device

### DIFF
--- a/hubigraph_gauge.groovy
+++ b/hubigraph_gauge.groovy
@@ -524,7 +524,6 @@ async function onLoad() {
     websocket.onmessage = (event) => {
         parseEvent(JSON.parse(event.data));
     }
-    //BJC
     websocket.onclose = () => {
         console.log("WebSocket Closed!");
     }


### PR DESCRIPTION
I was hoping to start a discussion with this pull request, this works as-is but possibly you have a better way?

What I am after is to provide before/after hooks for when a tile is rendered and when it goes away, directly correlates to window.onLoad and window.onBeforeUnload.

Backstory: I have a power meter that has an MQTT topic for instantaneous demand, it is published every three seconds. I have written a device driver for it and I have commands to start/stop the subscription to that topic. I was looking for a way to start the subscription when the tile renders, then stop it when the tile is no longer showing on a page. This way the hub is not doing unnecessary work every three seconds.

So these changes provide a select in the app settings where you can choose a command (offered by the sensor device) to run right before the tile loads, then you can choose another command to run right before it unloads.

There are two new endpoints exposed - onTileLoad and onTileUnload and two associated groovy methods by the same name that do the work.

I haven't looked at any of the other apps yet, just figured out where to splice this in on the guage for now.

Let me know any thoughts.

Thanks!
Ben

PS, I also fixed the window.onBeforeUnload while I was at it (I don't think this was working?)


